### PR TITLE
Fix boost video, extra modes playlist IDs + show ranks

### DIFF
--- a/RocketStats/RocketStats.cpp
+++ b/RocketStats/RocketStats.cpp
@@ -7,7 +7,7 @@
 #include "bakkesmod/wrappers/GameEvent/GameEventWrapper.h"
 #include "bakkesmod/wrappers/GameEvent/ServerWrapper.h"
 #include "bakkesmod/wrappers/ArrayWrapper.h"
-#include "bakkesmod\wrappers\includes.h"
+#include "bakkesmod/wrappers/includes.h"
 #include "utils/parser.h"
 #include <chrono>
 #include <thread>
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <fstream>
 
-BAKKESMOD_PLUGIN(RocketStats, "RocketStats", "1.4", 0)
+BAKKESMOD_PLUGIN(RocketStats, "RocketStats", "1.5", 0)
 
 #pragma region Helpers
 int HexadecimalToDecimal(std::string hex) {
@@ -483,23 +483,23 @@ void RocketStats::initRankList()
 	v1Rank.nameMode = "1v1";
 	v1Rank._rank = {
 		{"Bronze_I", {0.0f, 153.0f}},
-		{"Bronze_II", {148.0f, 213.9f}},
-		{"Bronze_III", {214.0f, 272.9f}},
-		{"Silver_I", {273.0f, 331.9f}},
-		{"Silver_II", {332.0f, 391.9f}},
-		{"Silver_III", {392.0f, 452.9f}},
-		{"Gold_I", {453.0f, 511.9f}},
-		{"Gold_II", {512.0f, 571.9f}},
-		{"Gold_III", {572.0f, 631.9f}},
-		{"Platinum_I", {632.0f, 686.9f}},
-		{"Platinum_II", {687.0f, 745.9f}},
-		{"Platinum_III", {746.0f, 810.9f}},
-		{"Diamond_I", {811.0f, 869.9f}},
-		{"Diamond_II", {870.0f, 925.9f}},
-		{"Diamond_III", {926.0f, 994.9f}},
-		{"Champion_I", {995.0f, 1073.9f}},
-		{"Champion_II", {1074.0f, 1151.9f}},
-		{"Champion_III", {1152.0f, 1220.9f}},
+		{"Bronze_II", {153.0f, 202.0f}},
+		{"Bronze_III", {213.0f, 264.0f}},
+		{"Silver_I", {273.0f, 324.0f}},
+		{"Silver_II", {332.0f, 384.0f}},
+		{"Silver_III", {392.0f, 445.0f}},
+		{"Gold_I", {453.0f, 505.0f}},
+		{"Gold_II", {513.0f, 565.0f}},
+		{"Gold_III", {572.0f, 625.0f}},
+		{"Platinum_I", {628.0f, 685.0f}},
+		{"Platinum_II", {687.0f, 745.0f}},
+		{"Platinum_III", {752.0f, 805.0f}},
+		{"Diamond_I", {808.0f, 865.0f}},
+		{"Diamond_II", {867.0f, 925.0f}},
+		{"Diamond_III", {926.0f, 985.0f}},
+		{"Champion_I", {995.0f, 1060.0f}},
+		{"Champion_II", {1075, 1143.0f}},
+		{"Champion_III", {1147.0f, 1220.0f}},
 		{"Grand_Champion", {1221.0f, 9999.0f}},
 	};
 
@@ -507,82 +507,186 @@ void RocketStats::initRankList()
 	Ranks v2Rank;
 	v2Rank.nameMode = "2v2";
 	v2Rank._rank = {
-		{"Bronze_I", {0.0f, 182.0f}},
-		{"Bronze_II", {189.0f, 246.0f}},
-		{"Bronze_III", {250.0f, 303.0f}},
-		{"Silver_I", {312.0f, 365.0f}},
-		{"Silver_II", {370.0f, 425.0f}},
-		{"Silver_III", {428.0f, 483.0f}},
-		{"Gold_I", {498.0f, 545.0f}},
-		{"Gold_II", {547.0f, 602.0f}},
-		{"Gold_III", {614.0f, 680.0f}},
-		{"Platinum_I", {695.0f, 760.0f}},
-		{"Platinum_II", {774.0f, 841.0f}},
-		{"Platinum_III", {854.0f, 920.0f}},
-		{"Diamond_I", {934.0f, 1001.0f}},
-		{"Diamond_II", {1014.0f, 1080.0f}},
-		{"Diamond_III", {1095.0f, 1180.0f}},
+		{"Bronze_I", {0.0f, 180.0f}},
+		{"Bronze_II", {189.0f, 244.0f}},
+		{"Bronze_III", {250.0f, 304.0f}},
+		{"Silver_I", {310.0f, 364.0f}},
+		{"Silver_II", {369.0f, 425.0f}},
+		{"Silver_III", {429.0f, 484.0f}},
+		{"Gold_I", {488.0f, 545.0f}},
+		{"Gold_II", {549.0f, 604.0f}},
+		{"Gold_III", {612.0f, 680.0f}},
+		{"Platinum_I", {692.0f, 760.0f}},
+		{"Platinum_II", {772.0f, 840.0f}},
+		{"Platinum_III", {852.0f, 920.0f}},
+		{"Diamond_I", {933.0f, 1000.0f}},
+		{"Diamond_II", {1012.0f, 1080.0f}},
+		{"Diamond_III", {1093.0f, 1180.0f}},
 		{"Champion_I", {1195.0f, 1280.0f}},
-		{"Champion_II", {1285.0f, 1380.0f}},
-		{"Champion_III", {1395.0f, 1500.0f}},
-		{"Grand_Champion", {1501.0f, 9999.0f}},
+		{"Champion_II", {1294.0f, 1380.0f}},
+		{"Champion_III", {1395.0f, 1499.0f}},
+		{"Grand_Champion", {1500.0f, 9999.0f}},
 	};
 
 	//solo 3v3 Ranked code : 12
 	Ranks sv3Rank;
 	sv3Rank.nameMode = "solo 3v3";
 	sv3Rank._rank = {
-		{"Bronze_I", {0.0f, 153.0f}},
-		{"Bronze_II", {150.0f, 209.0f}},
-		{"Bronze_III", {210.0f, 274.0f}},
-		{"Silver_I", {266.0f, 329.0f}},
-		{"Silver_II", {328.0f, 387.0f}},
-		{"Silver_III", {389.0f, 443.0f}},
-		{"Gold_I", {449.0f, 506.0f}},
-		{"Gold_II", {510.0f, 563.0f}},
-		{"Gold_III", {571.0f, 623.0f}},
-		{"Platinum_I", {630.0f, 683.0f}},
-		{"Platinum_II", {692.0f, 745.0f}},
-		{"Platinum_III", {753.0f, 804.0f}},
-		{"Diamond_I", {815.0f, 881.0f}},
-		{"Diamond_II", {895.0f, 961.0f}},
-		{"Diamond_III", {975.0f, 1042.0f}},
-		{"Champion_I", {1055.0f, 1123.0f}},
-		{"Champion_II", {1124.0f, 1201.0f}},
-		{"Champion_III", {1211.0f, 1292.0f}},
+		{"Bronze_I", {0.0f, 154.0f}},
+		{"Bronze_II", {151.0f, 208.0f}},
+		{"Bronze_III", {209.0f, 270.0f}},
+		{"Silver_I", {270.0f, 323.0f}},
+		{"Silver_II", {329.0f, 384.0f}},
+		{"Silver_III", {390.0f, 443.0f}},
+		{"Gold_I", {451.0f, 503.0f}},
+		{"Gold_II", {511.0f, 562.0f}},
+		{"Gold_III", {572.0f, 622.0f}},
+		{"Platinum_I", {635.0f, 683.0f}},
+		{"Platinum_II", {692.0f, 742.0f}},
+		{"Platinum_III", {749.0f, 804.0f}},
+		{"Diamond_I", {815.0f, 880.0f}},
+		{"Diamond_II", {895.0f, 960.0f}},
+		{"Diamond_III", {975.0f, 1041.0f}},
+		{"Champion_I", {1055.0f, 1120.0f}},
+		{"Champion_II", {1134.0f, 1203.0f}},
+		{"Champion_III", {1210.0f, 1283.0f}},
 		{"Grand_Champion", {1287.0f, 9999.0f}},
 	};
 
 	//3v3 Standard Ranked code : 13
 	Ranks v3Rank;
-	v3Rank.nameMode = "solo 3v3";
+	v3Rank.nameMode = "3v3";
 	v3Rank._rank = {
-		{"Bronze_I", {0.0f, 184.0f}},
-		{"Bronze_II", {185.0f, 251.0f}},
-		{"Bronze_III", {248.0f, 309.0f}},
-		{"Silver_I", {308.0f, 366.0f}},
-		{"Silver_II", {369.0f, 423.0f}},
-		{"Silver_III", {430.0f, 485.0f}},
-		{"Gold_I", {489.0f, 545.0f}},
-		{"Gold_II", {548.0f, 604.0f}},
-		{"Gold_III", {612.0f, 682.0f}},
-		{"Platinum_I", {695.0f, 761.0f}},
-		{"Platinum_II", {773.0f, 841.0f}},
-		{"Platinum_III", {854.0f, 920.0f}},
-		{"Diamond_I", {934.0f, 1001.0f}},
-		{"Diamond_II", {1012.0f, 1080.0f}},
-		{"Diamond_III", {1095.0f, 1180.0f}},
+		{"Bronze_I", {0.0f, 180.0f}},
+		{"Bronze_II", {189.0f, 244.0f}},
+		{"Bronze_III", {247.0f, 301.0f}},
+		{"Silver_I", {310.0f, 364.0f}},
+		{"Silver_II", {369.0f, 425.0f}},
+		{"Silver_III", {429.0f, 485.0f}},
+		{"Gold_I", {490.0f, 545.0f}},
+		{"Gold_II", {549.0f, 604.0f}},
+		{"Gold_III", {612.0f, 680.0f}},
+		{"Platinum_I", {693.0f, 760.0f}},
+		{"Platinum_II", {771.0f, 840.0f}},
+		{"Platinum_III", {852.0f, 920.0f}},
+		{"Diamond_I", {933.0f, 1000.0f}},
+		{"Diamond_II", {1011.0f, 1080.0f}},
+		{"Diamond_III", {1094.0f, 1180.0f}},
 		{"Champion_I", {1195.0f, 1280.0f}},
-		{"Champion_II", {1295.0f, 1380.0f}},
-		{"Champion_III", {1395.0f, 1499.0f}},
-		{"Grand_Champion", {1501.0f, 9999.0f}},
+		{"Champion_II", {1294.0f, 1380.0f}},
+		{"Champion_III", {1395.0f, 1500.0f}},
+		{"Grand_Champion", {1500.0f, 9999.0f}},
+	};
+
+	// Hoops code : 27
+	Ranks hopRank;
+	hopRank.nameMode = "hoops";
+	hopRank._rank = {
+		{"Bronze_I", {0.0f, 140.0f}},
+		{"Bronze_II", {141.0f, 203.0f}},
+		{"Bronze_III", {201.0f, 271.0f}},
+		{"Silver_I", {262.0f, 320.0f}},
+		{"Silver_II", {322.0f, 389.0f}},
+		{"Silver_III", {386.0f, 440.0f}},
+		{"Gold_I", {449.0f, 500.0f}},
+		{"Gold_II", {515.0f, 560.0f}},
+		{"Gold_III", {572.0f, 622.0f}},
+		{"Platinum_I", {632.0f, 683.0f}},
+		{"Platinum_II", {693.0f, 741.0f}},
+		{"Platinum_III", {752.0f, 804.0f}},
+		{"Diamond_I", {807.0f, 864.0f}},
+		{"Diamond_II", {868.0f, 922.0f}},
+		{"Diamond_III", {935.0f, 1000.0f}},
+		{"Champion_I", {1012.0f, 1082.0f}},
+		{"Champion_II", {1087.0f, 1162.0f}},
+		{"Champion_III", {1167.0f, 1240.0f}},
+		{"Grand_Champion", {1242.0f, 9999.0f}},
+	};
+
+	// Rumble code : 28
+	Ranks rumRank;
+	rumRank.nameMode = "rumble";
+	rumRank._rank = {
+		{"Bronze_I", {0.0f, 154.0f}},
+		{"Bronze_II", {146.0f, 211.0f}},
+		{"Bronze_III", {205.0f, 262.0f}},
+		{"Silver_I", {266.0f, 324.0f}},
+		{"Silver_II", {329.0f, 388.0f}},
+		{"Silver_III", {391.0f, 440.0f}},
+		{"Gold_I", {450.0f, 501.0f}},
+		{"Gold_II", {511.0f, 565.0f}},
+		{"Gold_III", {569.0f, 622.0f}},
+		{"Platinum_I", {630.0f, 685.0f}},
+		{"Platinum_II", {691.0f, 743.0f}},
+		{"Platinum_III", {748.0f, 802.0f}},
+		{"Diamond_I", {810.0f, 863.0f}},
+		{"Diamond_II", {870.0f, 923.0f}},
+		{"Diamond_III", {933.0f, 1000.0f}},
+		{"Champion_I", {1014.0f, 1081.0f}},
+		{"Champion_II", {1090.0f, 1160.0f}},
+		{"Champion_III", {1170.0f, 1240.0f}},
+		{"Grand_Champion", {1241.0f, 9999.0f}},
+	};
+
+	// Dropshot code : 29
+	Ranks dropRank;
+	dropRank.nameMode = "dropshot";
+	dropRank._rank = {
+		{"Bronze_I", {0.0f, 151.0f}},
+		{"Bronze_II", {146.0f, 206.0f}},
+		{"Bronze_III", {205.0f, 271.0f}},
+		{"Silver_I", {264.0f, 333.0f}},
+		{"Silver_II", {329.0f, 380.0f}},
+		{"Silver_III", {387.0f, 440.0f}},
+		{"Gold_I", {450.0f, 501.0f}},
+		{"Gold_II", {507.0f, 560.0f}},
+		{"Gold_III", {573.0f, 620.0f}},
+		{"Platinum_I", {635.0f, 681.0f}},
+		{"Platinum_II", {690.0f, 742.0f}},
+		{"Platinum_III", {755.0f, 802.0f}},
+		{"Diamond_I", {813.0f, 863.0f}},
+		{"Diamond_II", {870.0f, 924.0f}},
+		{"Diamond_III", {935.0f, 1000.0f}},
+		{"Champion_I", {1015.0f, 1081.0f}},
+		{"Champion_II", {1087.0f, 1160.0f}},
+		{"Champion_III", {1174.0f, 1253.0f}},
+		{"Grand_Champion", {1243.0f, 9999.0f}},
+	};
+
+	// Snowday code : 30
+	Ranks snowRank;
+	snowRank.nameMode = "snowday";
+	snowRank._rank = {
+		{"Bronze_I", {0.0f, 153.0f}},
+		{"Bronze_II", {154.0f, 213.0f}},
+		{"Bronze_III", {208.0f, 268.0f}},
+		{"Silver_I", {267.0f, 333.0f}},
+		{"Silver_II", {323.0f, 392.0f}},
+		{"Silver_III", {382.0f, 452.0f}},
+		{"Gold_I", {449.0f, 503.0f}},
+		{"Gold_II", {515.0f, 568.0f}},
+		{"Gold_III", {575.0f, 620.0f}},
+		{"Platinum_I", {635.0f, 682.0f}},
+		{"Platinum_II", {695.0f, 740.0f}},
+		{"Platinum_III", {750.0f, 800.0f}},
+		{"Diamond_I", {813.0f, 861.0f}},
+		{"Diamond_II", {867.0f, 923.0f}},
+		{"Diamond_III", {935.0f, 1000.0f}},
+		{"Champion_I", {1015.0f, 1080.0f}},
+		{"Champion_II", {1089.0f, 1160.0f}},
+		{"Champion_III", {1170.0f, 1239.0f}},
+		{"Grand_Champion", {1241.0f, 9999.0f}},
 	};
 
 	listRank = {
 		{10, v1Rank},
 		{11, v2Rank},
 		{12, sv3Rank},
-		{13, v3Rank}
+		{13, v3Rank},
+		{27, hopRank},
+		{28, rumRank},
+		{29, dropRank},
+		{30, snowRank}
 	};
 }
 
@@ -605,7 +709,7 @@ void RocketStats::majRank(int _gameMode, float _currentMMR)
 	currentMMR = _currentMMR;
 	lastRank == currentRank;
 
-	if (currentGameMode >= 10 && currentGameMode <= 13)
+	if (currentGameMode >= 10 && currentGameMode <= 13 || currentGameMode >= 27 && currentGameMode <= 30)
 	{
 		for (auto it = listRank[currentGameMode]._rank.begin(); it != listRank[currentGameMode]._rank.end(); it++)
 		{

--- a/RocketStats/RocketStats.h
+++ b/RocketStats/RocketStats.h
@@ -1,9 +1,9 @@
 #pragma once
-#pragma comment( lib, "bakkesmod.lib" )
+#pragma comment( lib, "pluginsdk.lib" )
 #include "bakkesmod/plugin/bakkesmodplugin.h"
-#include "bakkesmod\plugin\pluginwindow.h"
+#include "bakkesmod/plugin/pluginwindow.h"
 
-typedef struct {
+typedef struct Stats {
 	float myMMR = 0;
 	float MMRChange = 0;
 	int win = 0;
@@ -12,7 +12,7 @@ typedef struct {
 	bool isInit = 0;
 } Stats;
 
-typedef struct {
+typedef struct RGB {
 	unsigned char r;
 	unsigned char g;
 	unsigned char b;
@@ -21,10 +21,10 @@ typedef struct {
 class RocketStats : public BakkesMod::Plugin::BakkesModPlugin
 {
 
-	typedef struct {
+	typedef struct Ranks {
 		std::string nameMode;
 		std::map<std::string, std::pair<float, float>> _rank;
-	}Ranks;
+	} Ranks;
 
 private : 
 	std::shared_ptr<bool> enabled;
@@ -91,11 +91,11 @@ public:
 		{12, "Ranked Solo Standard"},
 		{13, "Ranked Standard"},
 		{14, "Mutator Mashup"},
-		{15, "Snow Day"},
 		{16, "Rocket Labs"},
-		{17, "Hoops"},
-		{18, "Rumble"},
-		{23, "Dropshot"},
+		{27, "Hoops"},
+		{28, "Rumble"},
+		{29, "Dropshot"},
+		{30, "Snowday"},
 	};
 	std::string getPlaylistName(int playlistID);
 };

--- a/boost.html
+++ b/boost.html
@@ -14,21 +14,29 @@
     document.getElementById("vid2").currentTime = 0;
     let save = "0";
     window.setInterval(() => {
-      fetch('BoostState.txt').then(response => response.text()).then(text => {
-        if (text == "1" && save != text) {
-          // Boost
-          document.getElementById("vid1").hidden = false;
-          document.getElementById("vid2").hidden = true;
-        } else if (text == "0" && save != text) {
-          // No Boost
-          document.getElementById("vid1").hidden = true;
-          document.getElementById("vid2").hidden = false;
-        } else if (text == "-1" && save != text) {
-          document.getElementById("vid1").hidden = true;
-          document.getElementById("vid2").hidden = true;
-        }
-        save = text;
-      })
+	  var rawFile = new XMLHttpRequest();
+		rawFile.open("GET", 'BoostState.txt', false);
+		rawFile.onreadystatechange = function () {
+			if(rawFile.readyState === 4) {
+				if(rawFile.status === 200 || rawFile.status == 0) {
+					var allText = rawFile.responseText;
+					if (allText == "1" && save != allText) {
+					// Boost
+					document.getElementById("vid1").hidden = false;
+					document.getElementById("vid2").hidden = true;
+					} else if (allText == "0" && save != allText) {
+					// No Boost
+					document.getElementById("vid1").hidden = true;
+					document.getElementById("vid2").hidden = false;
+					} else if (allText == "-1" && save != allText) {
+					document.getElementById("vid1").hidden = true;
+					document.getElementById("vid2").hidden = true;
+					}
+					save = allText;
+				}
+			}
+		}
+		rawFile.send(null);
     }, 100)
   </script>
 </body>


### PR DESCRIPTION
Changelog:

* Fix boost video not showing up in OBS
  - Using XMLHttpRequest instead of fetch as Chromium doesn't allow file:// scheme
  - Probably could be also workarounded by adding --allow-file-access-from-files flag to OBS shortcut
* Fix extra modes names (Hoops, Dropshot, Rumble, Snowday) not showing up
  - Due to making those modes ranked, Psyonix changed their playlistID - this fixes that
* Add extra modes MMR to display rank in OBS
* Change MMR values to be more up-to-date with trackers
  - Updated values from https://rocketleague.tracker.network/rocket-league/distribution
* Version bump to 1.5